### PR TITLE
Add ability to cast an attribute

### DIFF
--- a/spec/ohm_spec.cr
+++ b/spec/ohm_spec.cr
@@ -12,6 +12,7 @@ describe "Ohm" do
     attribute :b
     attribute :c
     attribute :d
+    attribute :e, -> (val : String) { val.to_i }
 
     index :a
     index :b
@@ -40,7 +41,7 @@ describe "Ohm" do
   end
 
   it "should define attributes, indices and uniques" do
-    assert_equal Set{"a", "b", "c", "d"}, Foo.attributes
+    assert_equal Set{"a", "b", "c", "d", "e"}, Foo.attributes
     assert_equal Set{"a", "b"}, Foo.indices
     assert_equal Set{"d"}, Foo.uniques
   end
@@ -58,6 +59,20 @@ describe "Ohm" do
     assert_equal "4", foo.d
   end
 
+  it "should accept a hash with non-string attributes" do
+    atts           = {"a" => "1", "b" => 2, :c => "3", :d => 4}
+    sanitized_atts = {"a" => "1", "b" => "2", "c" => "3", "d" => "4"}
+
+    foo = Foo.new(atts)
+
+    assert_equal sanitized_atts, foo.attributes
+
+    assert_equal "1", foo.a
+    assert_equal "2", foo.b
+    assert_equal "3", foo.c
+    assert_equal "4", foo.d
+  end
+
   it "should provide setters" do
     atts = {"a" => "1", "b" => "2", "c" => "3", "d" => "4"}
 
@@ -65,6 +80,14 @@ describe "Ohm" do
     foo.a = "2"
 
     assert_equal "2", foo.a
+  end
+
+  it "should cast an attribute if proc provided" do
+    atts = {"e" => "4"}
+
+    foo = Foo.new(atts)
+
+    assert_equal 4, foo.e
   end
 
   it "should have a nil id when new" do

--- a/src/ohm.cr
+++ b/src/ohm.cr
@@ -213,6 +213,22 @@ module Ohm
         attributes[{{name.id.stringify}}]?
       end
 
+      attribute_setter({{name}})
+    end
+
+    macro attribute(name, cast)
+      attributes.add({{name.id.stringify}})
+
+      def {{name.id}}
+        value = attributes[{{name.id.stringify}}]?
+        return unless value
+        {{cast}}.call value
+      end
+
+      attribute_setter({{name}})
+    end
+
+    macro attribute_setter(name)
       def {{name.id}}=(value)
         attributes[{{name.id.stringify}}] = value.to_s
       end
@@ -427,6 +443,14 @@ module Ohm
 
     def initialize(atts : Hash(String, String))
       merge(atts)
+    end
+
+    def initialize(atts : Hash)
+      sanitized_atts = atts.reduce({} of String => String) do |h, (k, v)|
+        h[k.to_s] = v.to_s
+        h
+      end
+      merge(sanitized_atts)
     end
 
     private def initialize(@id : String)


### PR DESCRIPTION
This change adds an ability to typecast the attribute value in getter similar to how it's done in [ruby version](https://github.com/soveran/ohm/blob/master/lib/ohm.rb#L1015).
Also added an ability to initialize the object with not only `Hash(String, String)` restriction but with any values in hash, for consistency.
Unfortunately I can't specify some "general" type for hash values and `String` for keys without dirty hacks due to the following issues:
https://github.com/crystal-lang/crystal/issues/2733
https://github.com/crystal-lang/crystal/issues/4572

Example:
```crystal
class Person < Ohm::Model
  attribute :name
  attribute :age, -> (val : String) { val.to_i }
end

bob = Person.create({"name" => "Bob", "age" => 42})
puts bob.name       # => Bob
puts bob.name.class # => String
puts bob.age        # => 42
puts bob.age.class  # => Int32
bob.age = 9000
puts bob.age        # => 9000
puts bob.age.class  # => Int32
```