### PR TITLE
Fix for Crystal 1.0

### DIFF
--- a/src/ohm.cr
+++ b/src/ohm.cr
@@ -53,7 +53,7 @@ module Ohm
     end
 
     def compact!
-      @pool.delete_if { |k, v| @pool[k].value.nil? }
+      @pool.reject! { |k, v| @pool[k].value.nil? }
     end
 
     def current


### PR DESCRIPTION
Fix for `(breaking-change) Deprecate Hash#delete_if in favor of Hash#reject!` in Crystal 1.0